### PR TITLE
Added missing CPACK lines to create .deb package using "make package"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,6 @@
 ## Authors
 
+* Stéphane Charette <stephanecharette@gmail.com>
 * Dominik Seichter <domseichter@web.de>
 * Leonard Rosenthol <leonardr@pdfsages.com>
 * Craig Ringer <craig@postnewspapers.com.au>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,3 +285,11 @@ endif()
 if(PDFMM_BUILD_STATIC)
     export(TARGETS pdfmm_static pdfmm_private FILE "${PROJECT_BINARY_DIR}/pdfmmConfig.cmake")
 endif()
+
+set(CPACK_PACKAGE_VENDOR "Francesco Pretto")
+set(CPACK_PACKAGE_CONTACT "ceztko@gmail.com")
+set(CPACK_PACKAGE_CONTACT "https://github.com/pdfmm/pdfmm")
+set(CPACK_PACKAGE_VERSION ${PDFMM_LIBVERSION})
+set(CPACK_GENERATOR "DEB")
+include(CPack)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,6 @@ endif()
 
 set(CPACK_PACKAGE_VENDOR "Francesco Pretto")
 set(CPACK_PACKAGE_CONTACT "ceztko@gmail.com")
-set(CPACK_PACKAGE_CONTACT "https://github.com/pdfmm/pdfmm")
 set(CPACK_PACKAGE_VERSION ${PDFMM_LIBVERSION})
 set(CPACK_GENERATOR "DEB")
 include(CPack)


### PR DESCRIPTION
When using Debian or Ubuntu based Linux distro, run "make package" to create the .deb installation file.

- [X] Checked coding [style](https://github.com/pdfmm/pdfmm/blob/master/CODING-STYLE.md)
- [X] Accept to license the code under the terms of the [LGPL 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
- [X] Added attribution in [AUTHORS.md](https://github.com/pdfmm/pdfmm/blob/master/AUTHORS.md)